### PR TITLE
add typings postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "type": "git",
     "url": "https://github.com/driftyco/ionic-conference-app.git"
   },
+  "scripts": {
+    "postinstall": "typings install"
+  },
   "dependencies": {
     "@angular/common": "2.0.0-rc.4",
     "@angular/compiler": "2.0.0-rc.4",
@@ -39,7 +42,8 @@
     "ionic-gulp-tslint": "^1.0.0",
     "run-sequence": "1.1.5",
     "tslint": "^3.10.1",
-    "tslint-ionic-rules": "0.0.5"
+    "tslint-ionic-rules": "0.0.5",
+    "typings": "^1.3.3"
   },
   "cordovaPlugins": [
     "cordova-plugin-whitelist",


### PR DESCRIPTION
After I did `npm install`, I had to do a manual `typings install` as well. This PR will make sure that `typings install` is executed after running `npm install` which makes cloning and running the project a little easier.